### PR TITLE
Minor README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In ex `/src/nhost/index.js`:
 import nhost from 'nhost-js-sdk';
 
 const config = {
-  endpoint: 'https://backend-xxxx.nhost.app',
+  base_url: 'https://backend-xxxx.nhost.app',
 };
 
 nhost.initializeApp(config);


### PR DESCRIPTION
changed endpoint to base_url in the README, this follows the codebase and removes the error that "app is not initialized" when running it on react-native