### PR TITLE
Add ability to remove onChanged hooks

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -327,6 +327,10 @@ export default class Auth {
     this.token_changed_functions.push(fn);
   }
 
+  public removeOnTokenChanged(fn: Function): void {
+    this.token_changed_functions = this.token_changed_functions.filter(e => fn !== e);
+  }
+
   public onAuthStateChanged(fn: Function): void {
     this.auth_changed_functions.push(fn);
 
@@ -343,6 +347,10 @@ export default class Auth {
     };
 
     return unsubscribe;
+  }
+
+  public removeOnAuthStateChanged(fn: Function): void {
+    this.auth_changed_functions = this.auth_changed_functions.filter(e => fn !== e);
   }
 
   public isAuthenticated(): boolean | null {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -222,6 +222,7 @@ export default class Auth {
     // set new jwt_token
     if (jwt_token) {
       this.JWTMemory.setJWT(jwt_token);
+      this.tokenChanged();
     }
 
     // early exit
@@ -380,7 +381,6 @@ export default class Auth {
       await this.setItem("refresh_token", res.data.refresh_token);
     }
 
-    this.tokenChanged();
     this.setLoginState(true, res.data.jwt_token, res.data.jwt_expires_in);
   }
 


### PR DESCRIPTION
We needed a way to remove the onChanged hooks so added this.
Also moved the onTokenChanged trigger to when the token is actually set.