### PR TITLE
Fix type of getClaim

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -374,7 +374,7 @@ export default class Auth {
     return this.JWTMemory.getJWT();
   }
 
-  public getClaim(claim: string): string {
+  public getClaim(claim: string): string | string[] {
     return this.JWTMemory.getClaim(claim);
   }
 


### PR DESCRIPTION
`getClaim` can also return an array of strings.
E.g. `"x-hasura-allowed-roles": ["user", "me"]`