### PR TITLE
Ensure there is a JWT token to decode

### DIFF
--- a/src/NhostClient.ts
+++ b/src/NhostClient.ts
@@ -17,26 +17,13 @@ export default class NhostClient {
   storage: NhostStorage;
 
   constructor(config: types.UserConfig) {
-    if ("base_url" in config) {
-      console.error("use `baseURL` instead of `base_url` to initiate nhost");
-      return;
-    }
-
-    if ("baseUrl" in config) {
-      console.error(
-        "use `baseURL` (URL is uppercase) instead of `baseUrl` to initiate nhost"
-      );
-      return;
-    }
-
     if (!config.baseURL)
-      throw "The client needs a baseURL. Read more here: https://docs.nhost.io/libraries/nhost-js-sdk#setup.";
+      throw "Please specify a baseURL. More information at https://docs.nhost.io/libraries/nhost-js-sdk#setup.";
 
-    // this.JWTMemory = new JWTMemory();
-    this.session = new UserSession(); 
     this.baseURL = config.baseURL;
-    this.refreshIntervalTime = config.refreshIntervalTime || null; // 10 minutes (600 seconds)
     this.ssr = config.ssr ?? typeof window === "undefined";
+    this.session = new UserSession(); 
+    this.refreshIntervalTime = config.refreshIntervalTime || null; // 10 minutes (600 seconds)
 
     this.clientStorage = this.ssr
       ? {}

--- a/src/NhostClient.ts
+++ b/src/NhostClient.ts
@@ -11,7 +11,7 @@ export default class NhostClient {
   private clientStorageType: string;
   private ssr: boolean;
   private autoLogin: boolean;
-  private session: UserSession
+  private session: UserSession;
 
   auth: NhostAuth;
   storage: NhostStorage;
@@ -22,7 +22,10 @@ export default class NhostClient {
 
     this.baseURL = config.baseURL;
     this.ssr = config.ssr ?? typeof window === "undefined";
-    this.session = new UserSession(); 
+    this.useCookies = config.useCookies ?? false;
+    this.autoLogin = config.autoLogin ?? true;
+
+    this.session = new UserSession();
     this.refreshIntervalTime = config.refreshIntervalTime || null; // 10 minutes (600 seconds)
 
     this.clientStorage = this.ssr
@@ -33,26 +36,26 @@ export default class NhostClient {
       ? config.clientStorageType
       : "web";
 
-    this.useCookies = config.useCookies ?? false;
-    this.autoLogin = config.autoLogin ?? true;
+    this.auth = new NhostAuth(
+      {
+        baseURL: this.baseURL,
+        useCookies: this.useCookies,
+        refreshIntervalTime: this.refreshIntervalTime,
+        clientStorage: this.clientStorage,
+        clientStorageType: this.clientStorageType,
+        ssr: this.ssr,
+        autoLogin: this.autoLogin,
+      },
+      this.session
+    );
+    // this.auth = new NhostAuth(authConfig, this.session);
 
-    const authConfig = {
-      baseURL: this.baseURL,
-      useCookies: this.useCookies,
-      refreshIntervalTime: this.refreshIntervalTime,
-      clientStorage: this.clientStorage,
-      clientStorageType: this.clientStorageType,
-      ssr: this.ssr,
-      autoLogin: this.autoLogin,
-    };
-    // this.auth = new NhostAuth(authConfig, this.JWTMemory);
-    this.auth = new NhostAuth(authConfig, this.session);
-
-    const storageConfig = {
-      baseURL: this.baseURL,
-      useCookies: this.useCookies,
-    };
-
-    this.storage = new NhostStorage(storageConfig, this.session);
+    this.storage = new NhostStorage(
+      {
+        baseURL: this.baseURL,
+        useCookies: this.useCookies,
+      },
+      this.session
+    );
   }
 }

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -7,6 +7,7 @@ import {
   utf8Bytes,
   percentEncodedBytes,
 } from "./utils";
+// @ts-ignore
 import Blob from "node-blob";
 
 export default class Storage {
@@ -50,7 +51,7 @@ export default class Storage {
 
     // todo: handle metadata
     if (metadata !== null) {
-      console.warn("Metadata is not yet handled in this NHOST JS SDK.");
+      console.warn("Metadata is not yet handled in this version..");
     }
 
     const upload_res = await this.httpClient.post(
@@ -72,21 +73,18 @@ export default class Storage {
     path: string,
     data: string,
     type: StringFormat = "raw",
-    metadata: object | null = null,
+    metadata: { "content-type": string } | null = null,
     onUploadProgress: any | undefined = undefined
   ) {
-    // todo: handle metadata
-    // if (metadata !== null) {
-    //   console.warn("Metadata is not yet handled in this NHOST JS SDK.");
-    // }
-
     let blob;
     if (type === "raw") {
       const fileData = utf8Bytes(data);
+
       const contentType =
         metadata && metadata.hasOwnProperty("content-type")
           ? metadata["content-type"]
           : null;
+
       blob = new Blob([fileData], { type: contentType });
     } else if (type === "data_url") {
       let isBase64 = false;

--- a/src/UserSession.ts
+++ b/src/UserSession.ts
@@ -13,8 +13,10 @@ export default class UserSession {
   public setSession(session: Session) {
     this.session = session;
 
-    const jwtTokenDecoded: JWTClaims = jwt_decode(session.jwt_token);
-    this.claims = jwtTokenDecoded["https://hasura.io/jwt/claims"];
+    if (session.jwt_token) {
+      const jwtTokenDecoded: JWTClaims = jwt_decode(session.jwt_token);
+      this.claims = jwtTokenDecoded["https://hasura.io/jwt/claims"];
+    }
   }
 
   public clearSession() {

--- a/src/UserSession.ts
+++ b/src/UserSession.ts
@@ -1,31 +1,36 @@
 import jwt_decode from "jwt-decode";
-import { Session } from "./types";
+import { Session, JWTClaims, JWTHasuraClaims } from "./types";
 
 export default class UserSession {
   private session: Session | null;
-  private claims: string[];
+  private claims: JWTHasuraClaims | null;
 
   constructor() {
     this.session = null;
-    this.claims = [];
+    this.claims = null;
   }
 
-  public setSession(session: Session | null) {
+  public setSession(session: Session) {
     this.session = session;
 
-    if (session) {
-      const jwtTokenDecoded: string[] = jwt_decode(session.jwt_token);
-      this.claims = jwtTokenDecoded["https://hasura.io/jwt/claims"];
-    } else {
-      this.claims = [];
-    }
+    const jwtTokenDecoded: JWTClaims = jwt_decode(session.jwt_token);
+    this.claims = jwtTokenDecoded["https://hasura.io/jwt/claims"];
+  }
+
+  public resetSession() {
+    this.session = null;
+    this.claims = null;
   }
 
   public getSession(): Session | null {
     return this.session;
   }
 
-  public getClaim(claim: string): string {
-    return this.claims[claim];
+  public getClaim(claim: string): string | string[] | null {
+    if (this.claims) {
+      return this.claims[claim];
+    } else {
+      return null;
+    }
   }
 }

--- a/src/UserSession.ts
+++ b/src/UserSession.ts
@@ -17,7 +17,7 @@ export default class UserSession {
     this.claims = jwtTokenDecoded["https://hasura.io/jwt/claims"];
   }
 
-  public resetSession() {
+  public clearSession() {
     this.session = null;
     this.claims = null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface ClientStorage {
   // localStorage
   // AsyncStorage
   // https://react-native-community.github.io/async-storage/docs/usage
-  setItem?: (key: string, value: unknown) => void;
+  setItem?: (key: string, value: string) => void;
   getItem?: (key: string) => any;
   removeItem?: (key: string) => void;
 
@@ -94,4 +94,17 @@ export interface User {
   email?: string;
   display_name?: string;
   avatar_url?: string;
+}
+export interface JWTHasuraClaims {
+  [claim: string]: string | string[];
+  "x-hasura-allowed-roles" : string[];
+  "x-hasura-default-role": string;
+  "x-hasura-user-id": string;
+}
+
+// https://hasura.io/docs/1.0/graphql/core/auth/authentication/jwt.html#the-spec
+export interface JWTClaims {
+  sub?: string;
+  iat?: number;
+  "https://hasura.io/jwt/claims": JWTHasuraClaims;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,27 @@
 {
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/test"
+  ],
   "compilerOptions": {
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "esModuleInterop": true,
     "declaration": true,
-    "strictNullChecks": true,
+    "strict": true,
     "target": "es5",
     "outDir": "dist",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
-    "lib": ["es2020", "dom"],
-    "rootDir": "src"
-  },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/test"]
+    "rootDir": "src",
+    "noUnusedLocals": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,7 +2689,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.19:
+lodash@^4.17.13, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
When `VERIFY_EMAILS` is true, `jwt-decode` will try and decode `null` after a new registration, which will then throw a `InvalidTokenError`.

This PR adds a check to ensure there is a JWT to be decoded.