### PR TITLE
Http only cookies

### DIFF
--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -276,8 +276,8 @@ export default class Auth {
     return this.currentSession.getClaim(claim);
   }
 
-  public async refreshSession(): Promise<void> {
-    return await this._refreshToken();
+  public async refreshSession(initRefreshToken?: string | null): Promise<void> {
+    return await this._refreshToken(initRefreshToken);
   }
 
   public async activate(ticket: string): Promise<void> {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -548,7 +548,7 @@ export default class Auth {
     const refreshToken =
       initRefreshToken || (await this._getItem("nhostRefreshToken"));
 
-    if (!refreshToken) {
+    if (!this.useCookies && !refreshToken) {
       // place at end of call-stack to let frontend get `null` first (to match SSR)
       setTimeout(() => {
         this._clearSession();

--- a/src/NhostClient.ts
+++ b/src/NhostClient.ts
@@ -26,7 +26,8 @@ export default class NhostClient {
     this.autoLogin = config.autoLogin ?? true;
 
     this.session = new UserSession();
-    this.refreshIntervalTime = config.refreshIntervalTime || null; // 10 minutes (600 seconds)
+    // Default JWTExpiresIn is 15 minutes (900000 miliseconds)
+    this.refreshIntervalTime = config.refreshIntervalTime || null;
 
     this.clientStorage = this.ssr
       ? {}


### PR DESCRIPTION
This PR:
- [x] Add `initRefreshToken` to `Auth.refreshSession` for consistency, the only line is to call a private method but didn't allow to pass its parameter.
- [x] Skip early return in `Auth._refreshToken` if `useCookies` is set, this solves two problems for HttpOnly cookies, allowing the user to auto login and also to auto generate tokens. 